### PR TITLE
fix cloning of buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ function copy(src) {
 			dst = { message: src.message };
 		} else if (isBoolean(src) || isNumber(src) || isString(src)) {
 			dst = Object(src);
+		} else if (src instanceof Buffer) {
+			dst = Buffer.alloc(src.length, src);
+		} else if (src instanceof Uint8Array || src instanceof ArrayBuffer) {
+			dst = src.slice(0);
 		} else if (Object.create && Object.getPrototypeOf) {
 			dst = Object.create(Object.getPrototypeOf(src));
 		} else if (src.constructor === Object) {

--- a/test/mutability.js
+++ b/test/mutability.js
@@ -77,6 +77,32 @@ test('cloneT', function (t) {
 	t.end();
 });
 
+test('cloneBuffer', function (t) {
+	var obj = { buffer: Buffer.from('hi', 'utf-8') };
+	var res = traverse.clone(obj);
+	t.same(res.buffer.toString(), 'hi');
+	t.same(obj, res);
+	t.ok(obj !== res);
+	t.end();
+});
+
+test('cloneUint8Array', function (t) {
+	var obj = { buffer: new TextEncoder().encode('hi') };
+	var res = traverse.clone(obj);
+	t.same(new TextDecoder().decode(res.buffer), 'hi');
+	t.same(obj, res);
+	t.ok(obj !== res);
+	t.end();
+});
+
+test('cloneArrayBuffer', function (t) {
+	var obj = { buffer: new ArrayBuffer(10) };
+	var res = traverse.clone(obj);
+	t.same(obj, res);
+	t.ok(obj !== res);
+	t.end();
+});
+
 test('reduce', function (t) {
 	var obj = { a: 1, b: 2, c: [3, 4] };
 	var res = traverse(obj).reduce(function (acc, x) {


### PR DESCRIPTION
Properly handles cloning of buffers in Node.js and browser environments.

Without this fix, Buffer objects would get corrupted after cloning as is demonstrated by the unit test.

Note: I'm not sure / haven't tested if this works in all browsers that this library supports.