### PR TITLE
Fix cloning typed arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var whichTypedArray = require('which-typed-array');
 var taSlice = require('typedarray.prototype.slice');
+var gopd = require('gopd');
 
 // TODO: use call-bind, is-date, is-regex, is-string, is-boolean-object, is-number-object
 function toS(obj) { return Object.prototype.toString.call(obj); }
@@ -56,6 +57,14 @@ function ownEnumerableKeys(obj) {
 var hasOwnProperty = Object.prototype.hasOwnProperty || function (obj, key) {
 	return key in obj;
 };
+
+function isWritable(object, key) {
+	if (typeof gopd !== 'function') {
+		return true;
+	}
+
+	return !gopd(object, key).writable;
+}
 
 function copy(src) {
 	if (typeof src === 'object' && src !== null) {
@@ -200,7 +209,11 @@ function walk(root, cb) {
 				if (modifiers.pre) { modifiers.pre.call(state, state.node[key], key); }
 
 				var child = walker(state.node[key]);
-				if (immutable && hasOwnProperty.call(state.node, key)) {
+				if (
+					immutable
+					&& hasOwnProperty.call(state.node, key)
+					&& !isWritable(state.node, key)
+				) {
 					state.node[key] = child.node;
 				}
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 		]
 	},
 	"dependencies": {
+		"gopd": "^1.0.1",
 		"typedarray.prototype.slice": "^1.0.2",
 		"which-typed-array": "^1.1.15"
 	},


### PR DESCRIPTION
This attempts to fix Typed Array cloning.

---

I had to add a node version check in the tests because:
1. `TypedArray.from` [was added in node 4](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from)

<details>
<summary>Image of failed test runs in actions summary</summary>

<img width="364" alt="image" src="https://github.com/ljharb/js-traverse/assets/2230835/afadb43e-cbe2-45db-b0fe-d4e3a3fe7df6">

</details>

---

I have pre-run all the tests already here:
| Name | Link |
| --- | --- |
| Tests: node.js >= 10 | https://github.com/scagood/js-traverse/actions/runs/5943582826 |
| Tests: node.js < 10 | https://github.com/scagood/js-traverse/actions/runs/5943582822 |
| Tests: pretest/posttest | https://github.com/scagood/js-traverse/actions/runs/5943582818 |
