### PR TITLE
Revert "[New] support enumerable Symbol properties"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,7 @@
 		"no-invalid-this": 0,
 		"object-curly-newline": 0,
 		"sort-keys": 0,
+		"max-lines": "warn",
 	},
 
 	"overrides": [

--- a/test/has.js
+++ b/test/has.js
@@ -23,14 +23,29 @@ test('has', function (t) {
 		obj[globalSymbol][localSymbol] = 7;
 		obj[localSymbol] = 8;
 
-		st.equal(traverse(obj).has([globalSymbol]), true);
+		st.equal(traverse(obj).has([globalSymbol]), false);
+		st.equal(traverse(obj, { includeSymbols: true }).has([globalSymbol]), true);
+
 		st.equal(traverse(obj).has([globalSymbol, globalSymbol]), false);
-		st.equal(traverse(obj).has([globalSymbol, localSymbol]), true);
-		st.equal(traverse(obj).has([localSymbol]), true);
-		st.equal(traverse(obj).has([localSymbol]), true);
+		st.equal(traverse(obj, { includeSymbols: true }).has([globalSymbol, globalSymbol]), false);
+
+		st.equal(traverse(obj).has([globalSymbol, localSymbol]), false);
+		st.equal(traverse(obj, { includeSymbols: true }).has([globalSymbol, localSymbol]), true);
+
+		st.equal(traverse(obj).has([localSymbol]), false);
+		st.equal(traverse(obj, { includeSymbols: true }).has([localSymbol]), true);
+
+		st.equal(traverse(obj).has([Symbol('d')]), false);
+		st.equal(traverse(obj, { includeSymbols: true }).has([Symbol('d')]), false);
+
 		st.equal(traverse(obj).has([Symbol('e')]), false);
-		st.equal(traverse(obj).has([Symbol.for('d')]), true);
+		st.equal(traverse(obj, { includeSymbols: true }).has([Symbol('e')]), false);
+
+		st.equal(traverse(obj).has([Symbol.for('d')]), false);
+		st.equal(traverse(obj, { includeSymbols: true }).has([Symbol.for('d')]), true);
+
 		st.equal(traverse(obj).has([Symbol.for('e')]), false);
+		st.equal(traverse(obj, { includeSymbols: true }).has([Symbol.for('e')]), false);
 
 		st.end();
 	});


### PR DESCRIPTION
This reverts commit 7d659e78d43e69e6afc604e12b3ba3a5def0e46f.

The reason for this is that the new feature is a breaking change and should be versioned as such.

Fixes #5.